### PR TITLE
Added basic form field for CF Standard Names

### DIFF
--- a/src/components/FormFields/CFParameterField.test.tsx
+++ b/src/components/FormFields/CFParameterField.test.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import { CfParameterField } from "./CfParameterField";
+
+describe("CfParameterField", () => {
+   test("renders the CfParameterField component", () => {
+      render(<CfParameterField label="CF Parameter Input" />);
+   });
+});

--- a/src/components/FormFields/CfParameterField.css
+++ b/src/components/FormFields/CfParameterField.css
@@ -1,0 +1,13 @@
+.suggestions {
+   list-style: none;
+}
+
+.suggestions li {
+   list-style: none;
+   cursor: pointer;
+}
+
+.suggestions li:hover {
+   background-color: #d4d4d4;
+
+}

--- a/src/components/FormFields/CfParameterField.stories.tsx
+++ b/src/components/FormFields/CfParameterField.stories.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import CfParameterField from './CfParameterField';
+
+// More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+export default {
+   title: 'ReactComponentLibrary/CfParameterField',
+   component: CfParameterField,
+} as ComponentMeta<typeof CfParameterField>;
+
+// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
+const Template: ComponentStory<typeof CfParameterField> = (args) => <CfParameterField {...args} />;
+
+export const HelloWorld = Template.bind({});
+// More on args: https://storybook.js.org/docs/react/writing-stories/args
+HelloWorld.args = {
+   label: 'CF Standard Name Input',
+};

--- a/src/components/FormFields/CfParameterField.tsx
+++ b/src/components/FormFields/CfParameterField.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import './CfParameterField.css';
+
+export interface CfParameterFieldProps {
+   label: string;
+}
+
+const cf_standard = require('../../vocabulary_json/cf_standard.json');
+
+const CfParameterField = (props: CfParameterFieldProps) => {
+
+   const [value, setValue] = useState('');
+   const [showSuggestions, setShowSuggestions] = useState(false);
+   const suggestions = cf_standard.filter( name => name.standard_name.includes(value));
+
+   useEffect(() => {
+
+      if (value == '') {
+         setShowSuggestions(false);
+      } else {
+         setShowSuggestions(true);
+      }
+
+   }, [value]);
+
+   const suggest = event => {
+      setValue(event.target.value);
+   };
+
+   const selectName = event => { 
+      console.log(event.target.innerHTML);
+      setValue(event.target.innerHTML);
+      setShowSuggestions(false);
+   };
+
+   return (
+      <div className="cf_standard_name">
+         <span>CF Standard Name:</span>
+         <input
+            type="text"
+            value={value}
+            onChange={suggest}
+         />
+         {showSuggestions && (
+            <ul className="suggestions">
+               {suggestions.map(suggestion => (
+                  <li onClick={selectName} key={suggestion.standard_name}>{suggestion.standard_name}</li>
+               ))}
+            </ul>
+         )}
+      </div>
+   )
+}
+
+export default CfParameterField;

--- a/src/components/FormFields/index.ts
+++ b/src/components/FormFields/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CfParameterField';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as Button } from "./Button";
+export { default as CfParameterField } from './FormFields';


### PR DESCRIPTION
I've added a basic form component for CF Standard Names based on the cf_standard.json data.  Check it out with storybook by first making sure everything is installed (npm install) and then running "npm run storybook"